### PR TITLE
Add AOD Assessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ We welcome all Wear OS projects - free, paid, open or closed source! Check out o
 
 - [Clockwork](https://github.com/Turtlepaw/clockwork) - The all-in-one package manager and builder for Watch Face Studio Projects.
 - [XML Preprocessor](https://github.com/gondwanasoft/xml-preprocessor) - Allows Python expressions and reduces duplication in Google-Samsung Watch Face Format XML.
+- [Always On Display Assessor](https://github.com/gondwanasoft/wff-aod) - Tool for estimating AOD compliance of Watch Face Format screenshots or mockups.
 
 ### Guides
 


### PR DESCRIPTION
Project: tool for estimating AOD compliance of WFF screenshots or mockups.

Why it belongs: helps to meet relevant Play Store requirement.

Is actively maintained.